### PR TITLE
Added some things.

### DIFF
--- a/src/SonicGLvl/EditorApplication.cpp
+++ b/src/SonicGLvl/EditorApplication.cpp
@@ -859,6 +859,14 @@ bool EditorApplication::keyPressed(const OIS::KeyEvent &arg) {
 			{
 				editor_application->saveLevelDataGUI();
 			}
+			if (arg.key == OIS::KC_R)
+			{
+				if (editor_mode == EDITOR_NODE_QUERY_OBJECT || EDITOR_NODE_QUERY_GHOST)
+				{
+					toggleRotationSnap();
+					updateSelection();
+				}
+			}
 		}
 		else if (keyboard->isModifierDown(OIS::Keyboard::Alt))
 		{
@@ -876,7 +884,7 @@ bool EditorApplication::keyPressed(const OIS::KeyEvent &arg) {
 					updateSelection();
 				}
 			}
-		}
+}
 	}
 
 	// Global Mode Shortcuts

--- a/src/SonicGLvl/EditorApplication.cpp
+++ b/src/SonicGLvl/EditorApplication.cpp
@@ -849,10 +849,15 @@ bool EditorApplication::keyPressed(const OIS::KeyEvent &arg) {
 
 					loadGhostAnimations();
 					ghost_node = new GhostNode(NULL, scene_manager, model_library, material_library);
+					ghost_node->setPosition(Ogre::Vector3(viewport->getCamera()->getPosition() + viewport->getCamera()->getDirection()*10));
 				}
 
 				clearSelection();
 				editor_mode = (editor_mode == EDITOR_NODE_QUERY_GHOST ? EDITOR_NODE_QUERY_OBJECT : EDITOR_NODE_QUERY_GHOST);
+			}
+			if(arg.key == OIS::KC_S) 
+			{
+				editor_application->saveLevelDataGUI();
 			}
 		}
 		else if (keyboard->isModifierDown(OIS::Keyboard::Alt))
@@ -860,6 +865,15 @@ bool EditorApplication::keyPressed(const OIS::KeyEvent &arg) {
 			if (arg.key == OIS::KC_F) {
 				if (camera_manager) {
 					camera_manager->setForceCamera(!camera_manager->getForceCamera());
+				}
+			}
+
+			if (arg.key == OIS::KC_G) 
+			{
+				if (editor_mode == EDITOR_NODE_QUERY_GHOST)
+				{
+					ghost_node->setPosition(Ogre::Vector3(viewport->getCamera()->getPosition() + viewport->getCamera()->getDirection() * 10));
+					updateSelection();
 				}
 			}
 		}
@@ -905,6 +919,10 @@ bool EditorApplication::keyPressed(const OIS::KeyEvent &arg) {
 
 		if(arg.key == OIS::KC_6) {
 			editor_application->toggleNodeVisibility(EDITOR_NODE_GHOST);
+		}
+		if (arg.key == OIS::KC_O)
+		{
+			editor_application->openLevelGUI();
 		}
 	}
 

--- a/src/SonicGLvl/EditorApplication.cpp
+++ b/src/SonicGLvl/EditorApplication.cpp
@@ -859,14 +859,6 @@ bool EditorApplication::keyPressed(const OIS::KeyEvent &arg) {
 			{
 				editor_application->saveLevelDataGUI();
 			}
-			if (arg.key == OIS::KC_R)
-			{
-				if (editor_mode == EDITOR_NODE_QUERY_OBJECT || EDITOR_NODE_QUERY_GHOST)
-				{
-					toggleRotationSnap();
-					updateSelection();
-				}
-			}
 		}
 		else if (keyboard->isModifierDown(OIS::Keyboard::Alt))
 		{
@@ -884,7 +876,7 @@ bool EditorApplication::keyPressed(const OIS::KeyEvent &arg) {
 					updateSelection();
 				}
 			}
-}
+		}
 	}
 
 	// Global Mode Shortcuts

--- a/src/SonicGLvl/Resource.rc
+++ b/src/SonicGLvl/Resource.rc
@@ -18,12 +18,9 @@ IDR_TOOLMENU MENU
 {
     POPUP "File"
     {
-        MENUITEM "Open Stage...", IMD_OPEN_LEVEL
+        MENUITEM "Open Stage...\tCtrl+O", IMD_OPEN_LEVEL
         MENUITEM SEPARATOR
-        MENUITEM "Save Stage Data...", IMD_SAVE_LEVEL_DATA
-        MENUITEM "Save Stage Terrain...", IMD_SAVE_LEVEL_TERRAIN
-        MENUITEM SEPARATOR
-        MENUITEM "Export Scene as FBX...", IMD_EXPORT_SCENE_FBX
+        MENUITEM "Save Stage Data...\tCtrl+S", IMD_SAVE_LEVEL_DATA
         MENUITEM SEPARATOR
         MENUITEM "Close", IMD_CLOSE
     }
@@ -78,6 +75,9 @@ IDR_TOOLMENU MENU
         MENUITEM "Delete all Terrain...", IMD_CLEAN_TERRAIN
         MENUITEM SEPARATOR
         MENUITEM "Import FBX as Terrain...", IMD_IMPORT_TERRAIN_FBX
+        MENUITEM "Save Stage Terrain...", IMD_SAVE_LEVEL_TERRAIN
+        MENUITEM SEPARATOR
+        MENUITEM "Export Scene as FBX...", IMD_EXPORT_SCENE_FBX
         MENUITEM SEPARATOR
         MENUITEM "Generate Terrain Groups...", IMD_GENERATE_TERRAIN_GROUPS
     }


### PR DESCRIPTION
Ghost Sonic now spawns in front of camera, and he can be snapped back to in front of it with Alt+G if in ghost mode (Thanks to Sajid and Skyth for the help)
Added Ctrl+S to save stage data
Added Ctrl+O to open stages
Moved terrain items that was in File to Terrain.
Updated SonicGlvl.exe